### PR TITLE
Update VerifyEmail.php

### DIFF
--- a/src/VerifyEmail.php
+++ b/src/VerifyEmail.php
@@ -135,7 +135,14 @@
 
 
         $this->debug[] = 'Starting veriffication...';
-        if(preg_match("/^220/i", $out = fgets($this->connect))){
+        while( preg_match("/^220-/i", $out = fgets($this->connect)) ){
+          $this->debug_raw['fake_connect'][] = $out;          
+          usleep(10000); //some servers have delay
+        }
+
+        if( preg_match("/^220 /i", $out ) ){
+          $this->debug_raw['connect'] = $out;
+          $this->debug[] = 'Response: '.$out;
           $this->debug[] = 'Got a 220 response. Sending HELO...';
           fputs ($this->connect , "HELO ".$this->get_domain($this->verifier_email)."\r\n");
           $out = fgets ($this->connect);


### PR DESCRIPTION
Update for AOL and some firewalls (Scrollout F1)
because of:
`telnet mailin-02.mx.aol.com 25`
Response:
220-mtaig-maa03.mx.aol.com ESMTP Internet Inbound
220-AOL and its affiliated companies do not
220-authorize the use of its proprietary computers and computer
220-networks to accept, transmit, or distribute unsolicited bulk
220-e-mail sent from the internet.
220-Effective immediately:
220-AOL may no longer accept connections from IP addresses
220 which no do not have reverse-DNS (PTR records) assigned.

HELO must be send after last 220